### PR TITLE
check user-given type annotations

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,6 +3,6 @@
 (define deps '("base" "typed-racket-lib" "typed-racket-more"))
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define pkg-desc "require/typed without contracts")
-(define version "0.1")
+(define version "0.2")
 (define pkg-authors '(ben))
 (define scribblings '(("scribblings/require-typed-check.scrbl" () ("scripting"))))

--- a/private/require-typed-check.rkt
+++ b/private/require-typed-check.rkt
@@ -7,7 +7,7 @@
 )
 
 (require
-  (for-syntax racket/base syntax/location)
+  (for-syntax racket/base syntax/location syntax/parse)
   (only-in typed/racket require/typed)
   (rename-in typed/racket/no-check [require/typed require/typed/no-check]))
 
@@ -65,13 +65,106 @@
    [else
     l]))
 
+;; -----------------------------------------------------------------------------
+(begin-for-syntax
+  ;; This block is copied from:
+  ;;    https://github.com/racket/typed-racket/blob/master/typed-racket-lib/typed/private/no-check-helper.rkt#L17
+  ;; We use it to parse clauses for no-check.
+  ;; Except, I added the `ann` properties
+
+  (define-syntax-class opt-parent
+    #:attributes (nm parent)
+    (pattern nm:id #:with parent #'#f)
+    (pattern (nm:id parent:id)))
+
+  (define-syntax-class opt-rename
+    #:attributes (nm orig-nm spec)
+    (pattern nm:id
+      #:with orig-nm #'nm
+      #:with spec #'nm)
+    (pattern (orig-nm:id internal-nm:id)
+      #:with spec #'(orig-nm internal-nm)
+      #:with nm #'internal-nm))
+
+  (define-syntax-class simple-clause
+    #:attributes (nm ty)
+    (pattern [nm:opt-rename ty]))
+
+  (define-splicing-syntax-class (struct-opts struct-name)
+    #:attributes (ctor-value type)
+    (pattern (~seq (~optional (~seq (~and key (~or #:extra-constructor-name #:constructor-name))
+                              name:id))
+                   (~optional (~seq #:type-name type:id) #:defaults ([type struct-name])))
+      #:attr ctor-value (if (attribute key) #'(key name) #'())))
+
+  (define-syntax-class struct-clause
+    #:attributes (nm type (body 1) (constructor-parts 1) (tvar 1))
+    (pattern [(~or (~datum struct) #:struct)
+              (~optional (~seq (tvar ...)) #:defaults ([(tvar 1) '()]))
+              nm:opt-parent (body ...)
+              (~var opts (struct-opts #'nm.nm))]
+      #:with (constructor-parts ...) #'opts.ctor-value
+      #:attr type #'opts.type))
+
+  (define-syntax-class signature-clause
+    #:literals (:)
+    #:attributes (sig-name [var 1] [type 1])
+    (pattern [#:signature sig-name:id ([var:id : type] ...)]))
+
+  (define-syntax-class opaque-clause
+    #:attributes (ty pred opt)
+    (pattern [(~or (~datum opaque) #:opaque) ty:id pred:id]
+      #:with opt #'())
+    (pattern [(~or (~datum opaque) #:opaque) opaque ty:id pred:id #:name-exists]
+      #:with opt #'(#:name-exists)))
+
+  (define-syntax-class (clause lib)
+    #:attributes (ann req)
+      (pattern oc:opaque-clause
+        #:attr ann #'#f
+        #:attr req #`(require/typed #,lib (#:opaque oc.ty oc.pred . oc.opt)))
+      (pattern (~var strc struct-clause)
+        #:attr ann #'#f
+        #:attr req #'#f)
+        ; TODO check struct annotations
+        ;#:attr spec
+        ;#`(require-typed-struct strc.nm (strc.tvar ...)
+        ;    (strc.body ...) strc.constructor-parts ...
+        ;    #:type-name strc.type
+        ;    #,@(if unsafe? #'(unsafe-kw) #'())
+        ;    #,lib)
+      (pattern sig:signature-clause
+        #:attr ann #'#f
+        #:attr req #'#f)
+        ; TODO check signature annotations
+      (pattern sc:simple-clause
+        #:attr ann #'(ann sc.nm sc.ty)
+        #:attr req #'#f))
+)
+;; -----------------------------------------------------------------------------
+
 (define-syntax (require/typed/check stx)
-  (syntax-case stx ()
+  (syntax-parse stx
    [(_ lib clause* ...)
     (begin
-      (if (typed-lib? #'lib)
-        (syntax/loc stx (require/typed/no-check lib clause* ...))
-        (syntax/loc stx (require/typed lib clause* ...))))]
+      (if (not (typed-lib? #'lib))
+        ;; then : do a normal require/typed
+        (syntax/loc stx (require/typed lib clause* ...))
+        ;; else : do a no-check require/typed, but do check the type annotations
+        (syntax-parse #'(clause* ...)
+         [((~var c* (clause #'lib)) ...)
+          #:with (req* ...) (for/list ([req (in-list (syntax-e #'(c*.req ...)))]
+                                       #:when (syntax-e req))
+                              req)
+          #:with (ann* ...) (for/list ([ann (in-list (syntax-e #'(c*.ann ...)))]
+                                       #:when (syntax-e ann))
+                              ann)
+          (quasisyntax/loc stx
+            (begin
+              (require/typed/no-check lib clause* ...)
+              req* ...        ;; Import opaque types
+              (void ann* ...) ;; Check user-defined type annotations
+              ))])))]
    ;; Default to `require/typed` on bad syntax
    [(_ lib)
     (syntax/loc stx (require/typed lib))]

--- a/private/test-util.rkt
+++ b/private/test-util.rkt
@@ -1,0 +1,18 @@
+#lang typed/racket/base
+
+(provide
+  test-type-error
+)
+
+(require
+  typed/rackunit
+  (only-in racket/port open-output-nowhere))
+
+;; =============================================================================
+
+(define-syntax-rule (test-type-error stx ...)
+  (parameterize ([current-error-port (open-output-nowhere)])
+    (check-exn #rx"Type Checker"
+      (lambda ()
+        (compile-syntax stx)))
+    ...))

--- a/scribblings/require-typed-check.scrbl
+++ b/scribblings/require-typed-check.scrbl
@@ -17,22 +17,13 @@
   Known limitations:
   @itemlist[
     @item{
-      Type annotations are @bold{completely ignored} when importing from a typed
-       module.
-      The annotations can be wrong; they just get erased.
-    }
-    @item{
       All submodules of the current module are assumed untyped.
       The current implementation would need to compile the module's submodules
        to be sure; it breaks the circular dependency by assuming the worst.
     }
     @item{
-      Does not generate type definitions from @racket[#:opaque] imports
-       (but does require the predicate).
-      For example, after @racket[(require/typed/check .... [#:opaque Foo foo?])],
-       the predicate @racket[foo?] will be usable but the type @racket[Foo] will
-       not be.
-      Use @racket[require/typed] instead.
+      Any @racket[#:opaque] imports are required via @racket[require/typed].
+      (Previously, they weren't imported at all --- now they're imported under contract.)
     }
   ]
 }

--- a/test/README.md
+++ b/test/README.md
@@ -7,4 +7,5 @@ Index of tests for `require/typed/check`.
 - `bogus/` verify that type annotations are __completely ignored__ if the required module is typed
 - `fsm/` larger test, has order-of-magnitude speedup from `require/typed/check`
 - `opaque/` sadly, `#:opaque` types defined in typed modules are ignored
+- `pr/` assorted tests, from pull requests etc.
 - `submodule/` check that submodules are always assumed typed

--- a/test/basic/main.rkt
+++ b/test/basic/main.rkt
@@ -2,10 +2,10 @@
 
 (require require-typed-check)
 (require/typed/check require-typed-check/test/basic/untyped
-  (f (-> Natural Natural (Vectorof Any) Any)))
+  (f (-> Natural Natural (Vectorof Boolean) Any)))
 
 (require/typed/check require-typed-check/test/basic/typed
-  (g (-> Natural Natural (Vectorof Any) Any)))
+  (g (-> Natural Natural (Vectorof Boolean) Any)))
 
 (module+ test
   (require typed/rackunit)

--- a/test/bogus/main.rkt
+++ b/test/bogus/main.rkt
@@ -1,8 +1,16 @@
 #lang typed/racket/base
 
-(require require-typed-check)
+;; Cannot give bogus type annotations
+;; https://github.com/bennn/require-typed-check/issues/1
 
-(require/typed/check require-typed-check/test/bogus/typed
-  (f Void))
+(module+ test
+  (require
+    require-typed-check/private/test-util)
 
-(f 1 2)
+  (test-type-error
+    #'(module t typed/racket/base
+        (require require-typed-check)
+        (require/typed/check require-typed-check/test/bogus/typed
+          (f Void))
+        (f 1 2)))
+)

--- a/test/fsm/automata-adapted.rkt
+++ b/test/fsm/automata-adapted.rkt
@@ -12,7 +12,7 @@
 
 (require require-typed-check)
 (require/typed/check require-typed-check/test/fsm/automata
- ;[#:opaque Automaton automaton?]
+;[#:opaque Automaton automaton?]
 (#:struct automaton ({current : State}
                    {original : State}
                    {payoff : Payoff}

--- a/test/fsm/main.rkt
+++ b/test/fsm/main.rkt
@@ -22,13 +22,6 @@
  (relative-average (-> [Listof Real] Real Real))
 )
 
-;; effect: run timed simulation, create and display plot of average payoffs
-;; effect: measure time needed for the simulation
-(define (main)
-   (simulation->lines
-    (evolve (build-random-population 100) 500 10 20))
-   (void))
-
 (: simulation->lines (-> [Listof Payoff] [Listof [List Integer Real]]))
 ;; turn average payoffs into a list of Cartesian points 
 (define (simulation->lines data)
@@ -53,10 +46,17 @@
            ;; even though it is explicitly typed ... [Listof Payoff]
            (evolve p3 (- c 1) s r))]))
 
+;; effect: run timed simulation, create and display plot of average payoffs
+;; effect: measure time needed for the simulation
+(define (main)
+   (simulation->lines
+    (evolve (build-random-population 100) 500 10 20))
+   (void))
+
 ;; -----------------------------------------------------------------------------
 
 (module+ test
   (require require-typed-check)
   (require typed/racket/sandbox)
   (#{call-with-limits @ Void} 20 #f ;; TONS of time
-    (lambda () (begin (time (main)) (values (void))))))
+    (lambda () (begin (main) (values (void))))))

--- a/test/opaque/main.rkt
+++ b/test/opaque/main.rkt
@@ -18,14 +18,7 @@
   ;; Can use type from untyped module
   (define-type Foo Untyped)
 
-  ;; Cannot use type from typed module
-  (check-exn #rx"type name `Typed' is unbound"
-    (lambda ()
-      (compile-syntax
-        #'(module t typed/racket/base
-            (require require-typed-check)
-            (require/typed/check require-typed-check/test/opaque/typed
-              (#:opaque Typed typed?))
-            (define-type Bar Typed)))))
-
+  ;; Can use type from typed module, too
+  ;;  though it goes through a contract
+  (define-type Bar Typed)
 )

--- a/test/pr/1.rkt
+++ b/test/pr/1.rkt
@@ -1,0 +1,21 @@
+#lang typed/racket/base
+
+;; https://github.com/bennn/require-typed-check/issues/1
+
+(module+ test
+  (require require-typed-check/private/test-util)
+
+  (test-type-error
+    #'(module test racket/base
+        (module a typed/racket
+          (provide f)
+          (: f : (-> Positive-Fixnum Nonnegative-Fixnum))
+          (define (f x) (- x 1)))
+        (module b typed/racket
+          (require require-typed-check)
+          (require/typed/check (submod ".." a)
+            [f (-> String String)])
+          (f 5050))
+        (require 'b)))
+
+)


### PR DESCRIPTION
Initial support for checking typed-to-typed annotations. Fixes #1.

Typed-to-Typed imports are desugared to `(ann ...)` statements,
 to make sure the `require/typed/check` annotations are valid types.

There's still no contracts, we just double-check what you've written.
Unless you've written a `#:struct`.
